### PR TITLE
fix: types for solid

### DIFF
--- a/types/solid.d.ts
+++ b/types/solid.d.ts
@@ -1,11 +1,11 @@
 /* eslint-disable import/named */
 declare module 'virtual:icons/*' {
-  import { JSX } from 'solid-js'
-  const component: (props: JSX.StylableSVGAttributes) => JSX.Element
+  import { JSX, ComponentProps } from 'solid-js'
+  const component: (props: ComponentProps<'svg'>) => JSX.Element
   export default component
 }
 declare module '~icons/*' {
-  import { JSX } from 'solid-js'
-  const component: (props: JSX.StylableSVGAttributes) => JSX.Element
+  import { JSX, ComponentProps } from 'solid-js'
+  const component: (props: ComponentProps<'svg'>) => JSX.Element
   export default component
 }


### PR DESCRIPTION
the previous type didn't support properties like onclick. This commit
fix it.