### PR TITLE
chore: run/build `vite-vue3` example scripts uses wrong directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
   "scripts": {
     "build": "tsup src/*.ts --clean --format cjs,esm --dts --external vue && esno scripts/postbuild.ts",
     "dev": "tsup src/*.ts --clean --format cjs,esm --dts --watch src --external vue",
-    "example:build": "npm -C examples/vue3 run build",
-    "example:dev": "npm -C examples/vue3 run dev",
+    "example:build": "npm -C examples/vite-vue3 run build",
+    "example:dev": "npm -C examples/vite-vue3 run dev",
     "lint": "eslint --ext .ts,.js,.vue",
     "prepublishOnly": "npm run build",
     "release": "npx bumpp --commit --tag --push && npm publish"


### PR DESCRIPTION
On root `package.json` scripts, the run/build `vite-vue3` scripts point to `vue3` directory instead `vite-vue3`.

Running the `example:dev` script, `vue3` just works.