### PR TITLE
feat: add svelte compiler for props support

### DIFF
--- a/examples/sveltekit/src/routes/index.svelte
+++ b/examples/sveltekit/src/routes/index.svelte
@@ -6,7 +6,7 @@ import IconParkAbnormal from 'virtual:icons/icon-park/abnormal'
 </script>
 
 <main>
-  <SvelteLogo />
+  <SvelteLogo style="font-size:2em" />
   <br />
   <br />
   <MdiStore24Hour />

--- a/examples/vite-svelte/src/App.svelte
+++ b/examples/vite-svelte/src/App.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <main>
-  <SvelteLogo />
+  <SvelteLogo style="font-size:2em" />
   <br />
   <br />
   <MdiStore24Hour />

--- a/src/core/compilers/index.ts
+++ b/src/core/compilers/index.ts
@@ -3,6 +3,7 @@ import { JSXCompiler } from './jsx'
 import { NoneCompiler } from './none'
 import { RawCompiler } from './raw'
 import { SolidCompiler } from './solid'
+import { SvelteCompiler } from './svelte'
 import { Compiler } from './types'
 import { Vue2Compiler } from './vue2'
 import { Vue3Compiler } from './vue3'
@@ -12,7 +13,7 @@ export const compilers: Record<ResolvedOptions['compiler'], Compiler> = {
   'vue2': Vue2Compiler,
   'vue3': Vue3Compiler,
   'solid': SolidCompiler,
-  'svelte': NoneCompiler,
+  'svelte': SvelteCompiler,
   'jsx': JSXCompiler,
   'none': NoneCompiler,
   'raw': RawCompiler,

--- a/src/core/compilers/svelte.ts
+++ b/src/core/compilers/svelte.ts
@@ -1,0 +1,11 @@
+import { escapeSvelte } from '../utils'
+import { Compiler } from './types'
+
+export const SvelteCompiler = <Compiler>((svg: string) => {
+  const openTagEnd = svg.indexOf('>', svg.indexOf('<svg '))
+  const closeTagStart = svg.lastIndexOf('</svg>')
+  const openTag = `${svg.slice(0, openTagEnd)} {...$$props}>`
+  const content = `{@html \`${escapeSvelte(svg.slice(openTagEnd, closeTagStart))}\`}`
+  const closeTag = svg.slice(closeTagStart)
+  return `${openTag}${content}${closeTag}`
+})

--- a/src/core/compilers/svelte.ts
+++ b/src/core/compilers/svelte.ts
@@ -3,7 +3,7 @@ import { Compiler } from './types'
 
 export const SvelteCompiler = <Compiler>((svg: string) => {
   const openTagEnd = svg.indexOf('>', svg.indexOf('<svg '))
-  const closeTagStart = svg.lastIndexOf('</svg>')
+  const closeTagStart = svg.lastIndexOf('</svg')
   const openTag = `${svg.slice(0, openTagEnd)} {...$$props}>`
   const content = `{@html \`${escapeSvelte(svg.slice(openTagEnd, closeTagStart))}\`}`
   const closeTag = svg.slice(closeTagStart)

--- a/src/core/compilers/svelte.ts
+++ b/src/core/compilers/svelte.ts
@@ -1,4 +1,3 @@
-import { escapeSvelte } from '../utils'
 import { Compiler } from './types'
 
 export const SvelteCompiler = <Compiler>((svg: string) => {
@@ -9,3 +8,12 @@ export const SvelteCompiler = <Compiler>((svg: string) => {
   const closeTag = svg.slice(closeTagStart)
   return `${openTag}${content}${closeTag}`
 })
+
+// escape curlies, backtick, \t, \r, \n to avoid breaking output of {@html `here`} in .svelte
+export function escapeSvelte(str: string): string {
+  return str
+    .replace(/{/g, '&#123;')
+    .replace(/}/g, '&#125;')
+    .replace(/`/g, '&#96;')
+    .replace(/\\([trn])/g, ' ')
+}

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -14,3 +14,14 @@ export function camelToKebab(key: string) {
     .trim()
   return result.split(/\s+/g).join('-').toLowerCase()
 }
+
+// escape curlies, backtick, \t, \r, \n to avoid breaking output of {@html `here`} in .svelte
+export function escapeSvelte(str: string): string {
+  return str
+    .replace(
+      /[{}`]/g,
+      // @ts-ignore
+      c => ({ '{': '&#123;', '}': '&#125;', '`': '&#96;' }[c]),
+    )
+    .replace(/\\([trn])/g, '&#92;$1')
+}

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -18,10 +18,8 @@ export function camelToKebab(key: string) {
 // escape curlies, backtick, \t, \r, \n to avoid breaking output of {@html `here`} in .svelte
 export function escapeSvelte(str: string): string {
   return str
-    .replace(
-      /[{}`]/g,
-      // @ts-ignore
-      c => ({ '{': '&#123;', '}': '&#125;', '`': '&#96;' }[c]),
-    )
+    .replace(/{/g, '&#123;')
+    .replace(/}/g, '&#125;')
+    .replace(/`/g, '&#96;')
     .replace(/\\([trn])/g, ' ')
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -14,12 +14,3 @@ export function camelToKebab(key: string) {
     .trim()
   return result.split(/\s+/g).join('-').toLowerCase()
 }
-
-// escape curlies, backtick, \t, \r, \n to avoid breaking output of {@html `here`} in .svelte
-export function escapeSvelte(str: string): string {
-  return str
-    .replace(/{/g, '&#123;')
-    .replace(/}/g, '&#125;')
-    .replace(/`/g, '&#96;')
-    .replace(/\\([trn])/g, ' ')
-}

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -23,5 +23,5 @@ export function escapeSvelte(str: string): string {
       // @ts-ignore
       c => ({ '{': '&#123;', '}': '&#125;', '`': '&#96;' }[c]),
     )
-    .replace(/\\([trn])/g, '&#92;$1')
+    .replace(/\\([trn])/g, ' ')
 }


### PR DESCRIPTION
This PR adds a new compiler to allow passing props to the component:
- changed `compilers` to use this new `SvelteCompiler` instead `NoneCompiler`: it has been optimized to use [`{@html }`](https://svelte.dev/tutorial/html-tags) on svg content.
- added `escapeSvelte` utility function
- added style on svelte logo on `vite-svelte` and `svelte-kit` example projects.
