### PR TITLE
feat: add component resolver aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,20 +619,22 @@ IconsResolver({
 When using component resolver, you have to use the name of the collection that can be long or redundant: for example, 
 when using `icon-park` collection you need to use it like this `<icon-icon-park-abnormal />`.
 
-You can add an alias to the `IconResolver` plugin:
+You can add an alias for any collection to the `IconResolver` plugin:
 
 ```ts
 IconsResolver({
   alias: {
-    park: 'icon-park'
+    park: 'icon-park',
+    fas:  'fa-solid',
+    ...
   }
 })
 ```
 
-You can use the name using the alias or the collection name.
+You can use the alias or the collection name, the plugin will resolve both.
 
 Following with the example and configuring the plugin with previous `alias` entry, you can now use 
-`<icon-park-abnormal />` or `<icon-icon-park-abnormal />` 
+`<icon-park-abnormal />` or `<icon-icon-park-abnormal />`.
 
 ## Sponsors
 

--- a/README.md
+++ b/README.md
@@ -614,6 +614,26 @@ IconsResolver({
 </template>
 ```
 
+### Collection Aliases
+
+When using component resolver, you have to use the name of the collection that can be long or redundant: for example, 
+when using `icon-park` collection you need to use it like this `<icon-icon-park-abnormal />`.
+
+You can add an alias to the `IconResolver` plugin:
+
+```ts
+IconsResolver({
+  alias: {
+    park: 'icon-park'
+  }
+})
+```
+
+You can use the name using the alias or the collection name.
+
+Following with the example and configuring the plugin with previous `alias` entry, you can now use 
+`<icon-park-abnormal />` or `<icon-icon-park-abnormal />` 
+
 ## Sponsors
 
 This project is part of my <a href='https://github.com/antfu-sponsors'>Sponsor Program</a>

--- a/examples/vite-vue3/App.vue
+++ b/examples/vite-vue3/App.vue
@@ -28,6 +28,10 @@
       <i-inline-foo />
       <i-inline-async />
     </p>
+    <h2>Collection alias</h2>
+    <p>
+      <i-park-abnormal />
+    </p>
     from <code>unplugin-icons</code>
   </div>
 </template>

--- a/examples/vite-vue3/App.vue
+++ b/examples/vite-vue3/App.vue
@@ -31,6 +31,7 @@
     <h2>Collection alias</h2>
     <p>
       <i-park-abnormal />
+      <i-icon-park-abnormal />
     </p>
     from <code>unplugin-icons</code>
   </div>

--- a/examples/vite-vue3/components.d.ts
+++ b/examples/vite-vue3/components.d.ts
@@ -19,6 +19,7 @@ declare module 'vue' {
     IMdiDiceD12: typeof import('~icons/mdi/dice-d12')['default']
     IMdiLightAlarm: typeof import('~icons/mdi-light/alarm')['default']
     INotoV1FlagForFlagJapan: typeof import('~icons/noto-v1/flag-for-flag-japan')['default']
+    IParkAbnormal: typeof import('~icons/icon-park/abnormal')['default']
     IRiApps2Line: typeof import('~icons/ri/apps2-line')['default']
     ITwemoji1stPlaceMedal: typeof import('~icons/twemoji/1st-place-medal')['default']
   }

--- a/examples/vite-vue3/components.d.ts
+++ b/examples/vite-vue3/components.d.ts
@@ -9,6 +9,7 @@ declare module 'vue' {
     ICustomSteeringWheel: typeof import('~icons/custom/steering-wheel')['default']
     IFaSolidDiceFive: typeof import('~icons/fa-solid/dice-five')['default']
     IHeroiconsOutlineMenuAlt2: typeof import('~icons/heroicons-outline/menu-alt2')['default']
+    IIconParkAbnormal: typeof import('~icons/icon-park/abnormal')['default']
     IIcTwotone23mp: typeof import('~icons/ic/twotone23mp')['default']
     IIcTwotone24mp: typeof import('~icons/ic/twotone24mp')['default']
     IInlineAsync: typeof import('~icons/inline/async')['default']

--- a/examples/vite-vue3/vite.config.ts
+++ b/examples/vite-vue3/vite.config.ts
@@ -23,7 +23,7 @@ const config: UserConfig = {
       dts: true,
       resolvers: [
         IconsResolver({
-          aliases: {
+          alias: {
             park: 'icon-park',
           },
           customCollections: ['custom', 'inline'],

--- a/examples/vite-vue3/vite.config.ts
+++ b/examples/vite-vue3/vite.config.ts
@@ -23,6 +23,9 @@ const config: UserConfig = {
       dts: true,
       resolvers: [
         IconsResolver({
+          aliases: {
+            park: 'icon-park',
+          },
           customCollections: ['custom', 'inline'],
         }),
       ],

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -25,7 +25,7 @@ export interface ComponentResolverOption {
    *
    * The `aliases` keys are the `alias` and the values are the `name` for the collection.
    *
-   * Instead using `<i-icon-park-user />` we can use `<i-park-user />` configuring:
+   * Instead using `<i-icon-park-abnormal />` we can use `<i-park-abnormal />` configuring:
    * `alias: { park: 'icon-park' }`
    */
   alias?: Record<string, string>

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -74,8 +74,10 @@ export default function ComponentsResolver(options: ComponentResolverOption = {}
     ...toArray(customCollections),
   ])
 
-  // match longer name first
+  // add collection alias so user can use alias or full name
   Object.keys(aliases).forEach(c => collections.push(c))
+
+  // match longer name first
   collections.sort((a, b) => b.length - a.length)
 
   return (name: string) => {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -26,9 +26,9 @@ export interface ComponentResolverOption {
    * The `aliases` keys are the `alias` and the values are the `name` for the collection.
    *
    * Instead using `<i-icon-park-user />` we can use `<i-park-user />` configuring:
-   * `aliases: { park: 'icon-park' }`
+   * `alias: { park: 'icon-park' }`
    */
-  aliases?: Record<string, string>
+  alias?: Record<string, string>
 
   /**
    * Name for custom collections provide by loaders.
@@ -58,7 +58,7 @@ export default function ComponentsResolver(options: ComponentResolverOption = {}
   const {
     prefix: rawPrefix = options.componentPrefix ?? 'i',
     enabledCollections = Object.keys(Data.collections()),
-    aliases = {},
+    alias = {},
     customCollections = [],
     extension,
   } = options
@@ -72,10 +72,8 @@ export default function ComponentsResolver(options: ComponentResolverOption = {}
   const collections = uniq([
     ...toArray(enabledCollections),
     ...toArray(customCollections),
+    ...toArray(Object.keys(alias)),
   ])
-
-  // add collection alias so user can use alias or full name
-  Object.keys(aliases).forEach(c => collections.push(c))
 
   // match longer name first
   collections.sort((a, b) => b.length - a.length)
@@ -97,11 +95,11 @@ export default function ComponentsResolver(options: ComponentResolverOption = {}
     if (!icon)
       return
 
-    const useCollection = aliases[collection] || collection
+    const resolvedCollection = alias[collection] || collection
 
-    if (!customCollections.includes(useCollection) && !getBuiltinIcon(useCollection, icon))
+    if (!customCollections.includes(resolvedCollection) && !getBuiltinIcon(resolvedCollection, icon))
       return
 
-    return `~icons/${useCollection}/${icon}${ext}`
+    return `~icons/${resolvedCollection}/${icon}${ext}`
   }
 }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -21,6 +21,16 @@ export interface ComponentResolverOption {
   enabledCollections?: string | string[]
 
   /**
+   * Icon collections aliases.
+   *
+   * The `aliases` keys are the `alias` and the values are the `name` for the collection.
+   *
+   * Instead using `<i-icon-park-user />` we can use `<i-park-user />` configuring:
+   * `aliases: { park: 'icon-park' }`
+   */
+  aliases?: Record<string, string>
+
+  /**
    * Name for custom collections provide by loaders.
    */
   customCollections?: string | string[]
@@ -48,6 +58,7 @@ export default function ComponentsResolver(options: ComponentResolverOption = {}
   const {
     prefix: rawPrefix = options.componentPrefix ?? 'i',
     enabledCollections = Object.keys(Data.collections()),
+    aliases = {},
     customCollections = [],
     extension,
   } = options
@@ -64,6 +75,7 @@ export default function ComponentsResolver(options: ComponentResolverOption = {}
   ])
 
   // match longer name first
+  Object.keys(aliases).forEach(c => collections.push(c))
   collections.sort((a, b) => b.length - a.length)
 
   return (name: string) => {
@@ -83,9 +95,11 @@ export default function ComponentsResolver(options: ComponentResolverOption = {}
     if (!icon)
       return
 
-    if (!customCollections.includes(collection) && !getBuiltinIcon(collection, icon))
+    const useCollection = aliases[collection] || collection
+
+    if (!customCollections.includes(useCollection) && !getBuiltinIcon(useCollection, icon))
       return
 
-    return `~icons/${collection}/${icon}${ext}`
+    return `~icons/${useCollection}/${icon}${ext}`
   }
 }


### PR DESCRIPTION
Can also be used the long way: `<i-park-abnormal />` and `<i-icon-park-abnormal />`.

Only added one example on `vite-vue3`.

closes #39