### PR TITLE
fix: react types

### DIFF
--- a/types/react.d.ts
+++ b/types/react.d.ts
@@ -1,10 +1,10 @@
 declare module 'virtual:icons/*' {
-  import { SVGProps, JSX } from 'react'
-  const component: (props: SVGProps<SVGSVGElement>) => JSX.Element
+  import React, { SVGProps } from 'react'
+  const component: (props: SVGProps<SVGSVGElement>) => React.ReactElement
   export default component
 }
 declare module '~icons/*' {
-  import { SVGProps, JSX } from 'react'
-  const component: (props: SVGProps<SVGSVGElement>) => JSX.Element
+  import React, { SVGProps } from 'react'
+  const component: (props: SVGProps<SVGSVGElement>) => React.ReactElement
   export default component
 }

--- a/types/svelte.d.ts
+++ b/types/svelte.d.ts
@@ -1,7 +1,7 @@
-declare module "virtual:icons/*" {
-  export { SvelteComponentDev as default } from "svelte/internal";
+declare module 'virtual:icons/*' {
+  export { SvelteComponentDev as default } from 'svelte/internal'
 }
 
-declare module "~icons/*" {
-  export { SvelteComponentDev as default } from "svelte/internal";
+declare module '~icons/*' {
+  export { SvelteComponentDev as default } from 'svelte/internal'
 }


### PR DESCRIPTION
This PR also includes: 
- use single quotes on svelte types

The types seems to be ok with changes proposed on the issue, IntelliJ resolves also attrs:

![imagen](https://user-images.githubusercontent.com/6311119/135855190-f6d31bf9-4524-437f-ba9f-93a2d1138d70.png)

![imagen](https://user-images.githubusercontent.com/6311119/135855241-a50c9168-9911-4422-9428-144d34b79d2d.png)

fix #78