### PR TITLE
fix: get `default` method from @svgr/core (fixes #96)

### DIFF
--- a/src/core/compilers/jsx.ts
+++ b/src/core/compilers/jsx.ts
@@ -3,7 +3,8 @@ import { camelize } from '../utils'
 import { Compiler } from './types'
 
 export const JSXCompiler = <Compiler>(async(svg, collection, icon, options) => {
-  const svgr = (await importModule('@svgr/core')).default
+  // @svgr/core mixes default and named exports, which causes an akward extra `default` here
+  const svgr = (await importModule('@svgr/core')).default.default;
   let res = await svgr(svg, {}, { componentName: camelize(`${collection}-${icon}`) })
   // svgr does not provide an option to support preact (WHY?),
   // we manually remove the react import for preact


### PR DESCRIPTION
@svgr/core mixes their default and named exports, so we need to get the `default` export from their default export. 🙄   (See https://rollupjs.org/guide/en/#outputexports)