### PR TITLE
fix: remove extra `>` char on svelte and marko compilers

### DIFF
--- a/src/core/compilers/marko.ts
+++ b/src/core/compilers/marko.ts
@@ -4,7 +4,7 @@ export const MarkoCompiler = <Compiler>((svg: string) => {
   const openTagEnd = svg.indexOf('>', svg.indexOf('<svg '))
   const closeTagStart = svg.lastIndexOf('</svg')
   const openTag = `${svg.slice(0, openTagEnd)} ...input>`
-  const content = `$!{\`${escapeTemplateLiteral(svg.slice(openTagEnd, closeTagStart))}\`}`
+  const content = `$!{\`${escapeTemplateLiteral(svg.slice(openTagEnd + 1, closeTagStart))}\`}`
   const closeTag = svg.slice(closeTagStart)
   return `${openTag}${content}${closeTag}`
 })

--- a/src/core/compilers/svelte.ts
+++ b/src/core/compilers/svelte.ts
@@ -4,7 +4,7 @@ export const SvelteCompiler = <Compiler>((svg: string) => {
   const openTagEnd = svg.indexOf('>', svg.indexOf('<svg '))
   const closeTagStart = svg.lastIndexOf('</svg')
   const openTag = `${svg.slice(0, openTagEnd)} {...$$props}>`
-  const content = `{@html \`${escapeSvelte(svg.slice(openTagEnd, closeTagStart))}\`}`
+  const content = `{@html \`${escapeSvelte(svg.slice(openTagEnd + 1, closeTagStart))}\`}`
   const closeTag = svg.slice(closeTagStart)
   return `${openTag}${content}${closeTag}`
 })


### PR DESCRIPTION
closes #106