### PR TITLE
feat: use `importModule` instead `dynamic import`

### DIFF
--- a/src/core/compilers/vue2.ts
+++ b/src/core/compilers/vue2.ts
@@ -1,10 +1,11 @@
+import { importModule } from 'local-pkg'
 import { Compiler } from './types'
 
 // refer to: https://github.com/underfin/vite-plugin-vue2/blob/master/src/template/compileTemplate.ts
 export const Vue2Compiler = <Compiler>(async(svg: string, collection: string, icon: string) => {
-  const { compile } = await import('vue-template-compiler')
-  // @ts-expect-error
-  const transpile = (await import('vue-template-es2015-compiler')).default
+  const { compile } = await importModule('vue-template-compiler')
+  // @ts-ignore @ts-expect-error
+  const transpile = (await importModule('vue-template-es2015-compiler')).default
 
   const { render } = compile(svg)
   const toFunction = (code: string): string => {

--- a/src/core/compilers/vue3.ts
+++ b/src/core/compilers/vue3.ts
@@ -1,8 +1,9 @@
+import { importModule } from 'local-pkg'
 import { handleSVGId } from '../svgId'
 import { Compiler } from './types'
 
 export const Vue3Compiler = <Compiler>(async(svg: string, collection: string, icon: string) => {
-  const { compileTemplate } = await import('@vue/compiler-sfc')
+  const { compileTemplate } = await importModule('@vue/compiler-sfc')
 
   const { injectScripts, svg: handled } = handleSVGId(svg)
 
@@ -13,7 +14,7 @@ export const Vue3Compiler = <Compiler>(async(svg: string, collection: string, ic
   })
 
   code = code.replace(/^export /g, '')
-  code += `\n\nexport default { name: '${collection}-${icon}', render${ injectScripts ? `, data() {${injectScripts};return { idMap }}` : ''} }`
+  code += `\n\nexport default { name: '${collection}-${icon}', render${injectScripts ? `, data() {${injectScripts};return { idMap }}` : ''} }`
   code += '\n/* vite-plugin-components disabled */'
 
   return code


### PR DESCRIPTION
Instead using `dynamic import` now we use `importModule` from `local-pkg`  also on `vue2` and `vue3` compilers.

@antfu Review the `vue2` compiler changes since I cannot test on my local.

closes #120 