### PR TITLE
fix: resolve icons id without compiler option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,9 +34,7 @@ const unplugin = createUnplugin<Options>((options = {}) => {
               return `${res}.${ext.startsWith('.') ? ext.slice(1) : ext}`
           }
         }
-        else {
-          return res
-        }
+        return res
       }
       return null
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ const unplugin = createUnplugin<Options>((options = {}) => {
             if (ext)
               return `${res}.${ext.startsWith('.') ? ext.slice(1) : ext}`
           }
+        }
+        else {
           return res
         }
       }


### PR DESCRIPTION
Should fallback to return original `res` when user didn't provide compiler option.