### PR TITLE
fix(compiler-jsx): check for multiple svgr version

### DIFF
--- a/src/core/compilers/jsx.ts
+++ b/src/core/compilers/jsx.ts
@@ -3,7 +3,7 @@ import { camelize } from '../utils'
 import { Compiler } from './types'
 
 export const JSXCompiler = <Compiler>(async(svg, collection, icon, options) => {
-    const svgrCore = await importModule('@svgr/core')
+  const svgrCore = await importModule('@svgr/core')
   // check for v6 transform, v5 default and previous versions
   const svgr = svgrCore.transform || svgrCore.default || svgrCore
   let res = await svgr(svg, {}, { componentName: camelize(`${collection}-${icon}`) })

--- a/src/core/compilers/jsx.ts
+++ b/src/core/compilers/jsx.ts
@@ -3,7 +3,9 @@ import { camelize } from '../utils'
 import { Compiler } from './types'
 
 export const JSXCompiler = <Compiler>(async(svg, collection, icon, options) => {
-  const svgr = (await importModule('@svgr/core')).default
+    const svgrCore = await importModule('@svgr/core')
+  // check for v6 transform, v5 default and previous versions
+  const svgr = svgrCore.transform || svgrCore.default || svgrCore
   let res = await svgr(svg, {}, { componentName: camelize(`${collection}-${icon}`) })
   // svgr does not provide an option to support preact (WHY?),
   // we manually remove the react import for preact


### PR DESCRIPTION
This PR checks for `transform` for `v6`, `default` for `v5` and the module itself for previous versions.

/cc @dominikg for your svelte preprocessor

closes #96