### PR TITLE
feat: allow use raw compiler from query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,27 @@ For Svelte + Vite, on `src/vite-env.d.ts` file:
 
 <br></details>
 
+## Use RAW compiler from query params
+
+From `v0.13.2` you can also use `raw` compiler to access the `svg` icon and use it on your html templates, just add `raw` to the icon query param.
+
+For example, using `vue3`:
+
+```vue
+<script setup lang='ts'>
+  import RawMdiAlarmOff from '~icons/mdi/alarm-off?raw&width=4em&height=4em'
+  import RawMdiAlarmOff2 from '~icons/mdi/alarm-off?raw&width=1em&height=1em'
+</script>
+<template>
+  <pre>
+    import RawMdiAlarmOff from '~icons/mdi/alarm-off?raw&width=4em&height=4em'
+    {{ RawMdiAlarmOff }}
+    import RawMdiAlarmOff2 from '~icons/mdi/alarm-off?raw&width=1em&height=1em'
+    {{ RawMdiAlarmOff2 }}
+  </pre>
+</template>
+```
+
 ## Custom Icons
 
 From `v0.11`, you can now load your own icons!

--- a/README.md
+++ b/README.md
@@ -466,12 +466,16 @@ For example, using `vue3`:
   import RawMdiAlarmOff2 from '~icons/mdi/alarm-off?raw&width=1em&height=1em'
 </script>
 <template>
+  <!-- raw example -->
   <pre>
     import RawMdiAlarmOff from '~icons/mdi/alarm-off?raw&width=4em&height=4em'
     {{ RawMdiAlarmOff }}
     import RawMdiAlarmOff2 from '~icons/mdi/alarm-off?raw&width=1em&height=1em'
     {{ RawMdiAlarmOff2 }}
   </pre>
+  <!-- svg example -->
+  <span v-html="RawMdiAlarmOff"></span>
+  <span v-html="RawMdiAlarmOff2"></span>
 </template>
 ```
 

--- a/examples/sveltekit/src/routes/index.svelte
+++ b/examples/sveltekit/src/routes/index.svelte
@@ -3,6 +3,8 @@ import SvelteLogo from 'virtual:icons/logos/svelte-icon'
 import MdiStore24Hour from 'virtual:icons/mdi/store-24-hour'
 import MdiAlarmOff from 'virtual:icons/mdi/alarm-off'
 import IconParkAbnormal from 'virtual:icons/icon-park/abnormal'
+import RawMdiAlarmOff from 'virtual:icons/mdi/alarm-off?raw&width=4em&height=4em'
+import RawMdiAlarmOff2 from 'virtual:icons/mdi/alarm-off?raw&width=1em&height=1em'
 </script>
 
 <main>
@@ -12,6 +14,8 @@ import IconParkAbnormal from 'virtual:icons/icon-park/abnormal'
   <MdiStore24Hour />
   <MdiAlarmOff />
   <IconParkAbnormal />
+  {@html RawMdiAlarmOff}
+  {@html RawMdiAlarmOff2}
 </main>
 
 <style>

--- a/examples/sveltekit/svelte.config.js
+++ b/examples/sveltekit/svelte.config.js
@@ -8,7 +8,7 @@ const config = {
   preprocess: preprocess(),
   kit: {
     // hydrate the <div id="svelte"> element in src/app.html
-    target: '#svelte',
+    // target: '#svelte',
     vite: {
       plugins: [
         Icons({

--- a/examples/vite-preact/src/app.tsx
+++ b/examples/vite-preact/src/app.tsx
@@ -1,9 +1,11 @@
 import Logo from '~icons/logos/preact'
+import RawLogo from '~icons/logos/preact?raw'
 
 export function App() {
   return (
     <>
       <Logo style={{ fontSize: '3em' }} />
+      <span dangerouslySetInnerHTML={{ __html: RawLogo }}></span>
       <p>Hello Vite + Preact!</p>
       <p>
         <a

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import './App.css'
 import ReactLogo from '~icons/logos/react'
+import RawReactLogo from '~icons/logos/react?raw'
 
 function a() {
   return <svg/>
@@ -13,6 +14,7 @@ function App() {
     <div className="App">
       <header className="App-header">
         <ReactLogo style={{ fontSize: '3em' }} />
+        <span dangerouslySetInnerHTML={{ __html: RawReactLogo }}></span>
         <p>Hello Vite + React!</p>
         <p>
           <button type="button" onClick={() => setCount(count => count + 1)}>

--- a/examples/vite-svelte/src/App.svelte
+++ b/examples/vite-svelte/src/App.svelte
@@ -3,6 +3,8 @@
   import MdiStore24Hour from 'virtual:icons/mdi/store-24-hour'
   import MdiAlarmOff from 'virtual:icons/mdi/alarm-off'
   import IconParkAbnormal from 'virtual:icons/icon-park/abnormal'
+  import RawMdiAlarmOff from 'virtual:icons/mdi/alarm-off?raw&width=4em&height=4em'
+  import RawMdiAlarmOff2 from 'virtual:icons/mdi/alarm-off?raw&width=1em&height=1em'
 </script>
 
 <main>
@@ -12,6 +14,8 @@
   <MdiStore24Hour />
   <MdiAlarmOff />
   <IconParkAbnormal />
+  {@html RawMdiAlarmOff}
+  {@html RawMdiAlarmOff2}
 </main>
 
 <style>

--- a/examples/vite-vue3/App.vue
+++ b/examples/vite-vue3/App.vue
@@ -38,9 +38,14 @@
     <pre>
       import RawMdiAlarmOff from 'virtual:icons/mdi/alarm-off?raw&width=4em&height=4em'
       {{ RawMdiAlarmOff }}
+    </pre>
+    <span v-html="RawMdiAlarmOff"></span>
+    <pre>
       import RawMdiAlarmOff2 from 'virtual:icons/mdi/alarm-off?raw&width=1em&height=1em'
       {{ RawMdiAlarmOff2 }}
     </pre>
+    <span v-html="RawMdiAlarmOff2"></span>
+    <br/>
     from <code>unplugin-icons</code>
   </div>
 </template>

--- a/examples/vite-vue3/App.vue
+++ b/examples/vite-vue3/App.vue
@@ -34,6 +34,13 @@
       <i-park-abnormal />
       <i-icon-park-abnormal />
     </p>
+    <h2>Raw Icons from <strong>raw</strong> query param</h2>
+    <pre>
+      import RawMdiAlarmOff from 'virtual:icons/mdi/alarm-off?raw&width=4em&height=4em'
+      {{ RawMdiAlarmOff }}
+      import RawMdiAlarmOff2 from 'virtual:icons/mdi/alarm-off?raw&width=1em&height=1em'
+      {{ RawMdiAlarmOff2 }}
+    </pre>
     from <code>unplugin-icons</code>
   </div>
 </template>
@@ -42,4 +49,12 @@
 import MdiStore24Hour from 'virtual:icons/mdi/store-24-hour'
 import MdiAlarmOff from 'virtual:icons/mdi/alarm-off?width=4em&height=4em'
 import MdiAlarmOff2 from 'virtual:icons/mdi/alarm-off?width=1em&height=1em'
+import RawMdiAlarmOff from 'virtual:icons/mdi/alarm-off?raw&width=4em&height=4em'
+import RawMdiAlarmOff2 from 'virtual:icons/mdi/alarm-off?raw&width=1em&height=1em'
 </script>
+
+<style scoped>
+pre {
+  overflow-x: auto;
+}
+</style>

--- a/src/core/loader.ts
+++ b/src/core/loader.ts
@@ -33,7 +33,11 @@ export function resolveIconsPath(path: string): ResolvedIconPath | null {
     const queryRaw = path.slice(queryIndex + 1)
     path = path.slice(0, queryIndex)
     new URLSearchParams(queryRaw).forEach((value, key) => {
-      query[key] = value
+      // configure raw compiler for empty and true values only
+      if (key === 'raw')
+        query.raw = value === '' || value === 'true' ? 'true' : 'false'
+      else
+        query[key] = value
     })
   }
 
@@ -95,7 +99,8 @@ export async function generateComponent({ collection, icon, query }: ResolvedIco
   if (defaultStyle && !svg.includes(' style='))
     svg = svg.replace('<svg ', `<svg style="${defaultStyle}" `)
 
-  const _compiler = options.compiler
+  // accept raw compiler from query params
+  const _compiler = query.raw === 'true' ? 'raw' : options.compiler
 
   if (_compiler) {
     const compiler = typeof _compiler === 'string'

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -45,7 +45,8 @@ export async function mergeIconProps(
   await options?.iconCustomizer?.(collection, icon, props)
   Object.keys(query).forEach((p) => {
     const v = query[p]
-    if (v !== undefined && v !== null)
+    // exclude raw compiler entry to be serialized as svg attr
+    if (p !== 'raw' && v !== undefined && v !== null)
       props[p] = v
   })
   return svg.replace('<svg', `<svg ${Object.keys(props).map(p => `${p}="${props[p]}"`).join(' ')}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { createUnplugin } from 'unplugin'
 import { resolveOptions } from './core/options'
-import { generateComponentFromPath, isIconPath, normalizeIconPath } from './core/loader'
+import { generateComponentFromPath, isIconPath, normalizeIconPath, resolveIconsPath } from './core/loader'
 import type { Options } from './types'
 
 const unplugin = createUnplugin<Options>((options = {}) => {
@@ -14,7 +14,9 @@ const unplugin = createUnplugin<Options>((options = {}) => {
         const res = normalizeIconPath(id)
           .replace(/\.\w+$/i, '')
           .replace(/^\//, '')
-        const compiler = options.compiler
+        const resolved = resolveIconsPath(res)
+        // accept raw compiler from query params
+        const compiler = resolved?.query?.raw === 'true' ? 'raw' : options.compiler
         if (compiler && typeof compiler !== 'string') {
           const ext = compiler.extension
           if (ext)


### PR DESCRIPTION
Since there is only one compiler, we cannot use `raw` compiler when necessary, this PR will allow use `raw` in query param to use the svg on the html/sfc.

Included example on `vite-vue3` example, see screenshot on #151.

closes #151
closes #165