### PR TITLE
fix(compiler-vue3): RegExp miss multiline flag for clean export

### DIFF
--- a/src/core/compilers/vue3.ts
+++ b/src/core/compilers/vue3.ts
@@ -13,7 +13,7 @@ export const Vue3Compiler = <Compiler>(async(svg: string, collection: string, ic
     filename: `${collection}-${icon}.vue`,
   })
 
-  code = code.replace(/^export /g, '')
+  code = code.replace(/^export /gm, '')
   code += `\n\nexport default { name: '${collection}-${icon}', render${injectScripts ? `, data() {${injectScripts};return { idMap }}` : ''} }`
   code += '\n/* vite-plugin-components disabled */'
 


### PR DESCRIPTION
fix: 

```js
`import { createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"

const _hoisted_1 = { viewBox: "0 0 24 24" }
const _hoisted_2 = /*#__PURE__*/_createElementVNode("path", {
  fill: "currentColor",
  d: "M6 17c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6m9-9a3 3 0 0 1-3 3 3 3 0 0 1-3-3 3 3 0 0 1 3-3 3 3 0 0 1 3 3M3 5v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2Z"
}, null, -1 /* HOISTED */)
const _hoisted_3 = [
  _hoisted_2
]

export function render(_ctx, _cache) {
  return (_openBlock(), _createElementBlock("svg", _hoisted_1, _hoisted_3))
}`.replace(/^export /g, '')
```