### PR TITLE
chore: fix custom icons example

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ Icons({
     'my-icons': {
       account: '<svg><!-- ... --></svg>',
       // load your custom icon lazily
-      settings: () => fs.readFile('./path/to/my-icon.svg', 'utf-8'),
+      settings: () => fs.readFileSync('./path/to/my-icon.svg', 'utf-8'),
       /* ... */
     },
     'my-other-icons': async (iconName) => {


### PR DESCRIPTION
### Description

This is a simple fix on the README.

I was a little surprised when adding custom icons according to the guide and got error `my-icons/settings not found`. Then I figured `fs.readFile` is an async function that requires a callback, and this may not be the repo author's intent. After changing `fs.readFile` to `fs.readFileSync`, my custom icons worked.

### Linked Issues

Searching from the issues, I found this issue might be related:
https://github.com/antfu/unplugin-icons/issues/150
