### PR TITLE
docs: correct unplugin-vue-components import

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,7 +700,7 @@ Read [Cleaning up icons](https://docs.iconify.design/articles/cleaning-up-icons/
 `vite.config.json`
 
 ```diff
-import Components from 'unplugin-components/vite'
+import Components from 'unplugin-vue-components/vite'
 - import Icons, { ViteIconsResolver } from 'vite-plugin-icons'
 + import Icons from 'unplugin-icons/vite'
 + import IconsResolver from 'unplugin-icons/resolver'


### PR DESCRIPTION
### Description

I noticed the `unplugin-components` import in the `README.md` does not have any relevant npm package, I assumed it should have been the `unplugin-vue-components`.