### PR TITLE
fix: duplicate svg id in vue2 compiler

### DIFF
--- a/src/core/compilers/vue2.ts
+++ b/src/core/compilers/vue2.ts
@@ -1,4 +1,5 @@
 import { importModule } from 'local-pkg'
+import { handleSVGId } from '../svgId'
 import type { Compiler } from './types'
 
 // refer to: https://github.com/underfin/vite-plugin-vue2/blob/master/src/template/compileTemplate.ts
@@ -13,7 +14,9 @@ export const Vue2Compiler = <Compiler>(async (
   const transpile = (await importModule('vue-template-es2015-compiler'))
     .default
 
-  const { render } = compile(svg)
+  const { injectScripts, svg: handled } = handleSVGId(svg)
+
+  const { render } = compile(handled)
   const toFunction = (code: string): string => {
     return `function () {${code}}`
   }
@@ -31,6 +34,7 @@ export const Vue2Compiler = <Compiler>(async (
 /* vite-plugin-components disabled */
 export default {
   render: render,
+  ${injectScripts ? `data() {${injectScripts};return { idMap }},` : ''}
   name: '${collection}-${icon}',
 }
 `


### PR DESCRIPTION
### Description

It's a backported https://github.com/antfu/unplugin-icons/commit/0908f60074053e231eafba4fe02a4791b2bcc333 to vue2 compiler. Fixes #188.
