### PR TITLE
fix: nuxt 3.0.0 stable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,9 +335,9 @@ export default defineConfig({
 
 
 <details>
-<summary>Vue 3</summary><br>
+<summary>Vue 3 / Vue 2.7+</summary><br>
 
-Vue 3 support requires peer dependency `@vue/compiler-sfc`:
+Vue 3 / Vue 2.7+ support requires peer dependency `@vue/compiler-sfc`:
 
 ```bash
 npm i -D @vue/compiler-sfc
@@ -366,7 +366,7 @@ Type Declarations
 
 
 <details>
-<summary>Vue 2</summary><br>
+<summary>Vue 2 (only for versions < 2.7)</summary><br>
 
 Vue 2 support requires peer dependency `vue-template-compiler`:
 

--- a/examples/nuxt3/nuxt.config.ts
+++ b/examples/nuxt3/nuxt.config.ts
@@ -1,5 +1,3 @@
-import { defineNuxtConfig } from 'nuxt'
-
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 export default defineNuxtConfig({
   modules: [

--- a/examples/nuxt3/package.json
+++ b/examples/nuxt3/package.json
@@ -7,7 +7,8 @@
     "preview": "nuxt preview"
   },
   "devDependencies": {
-    "@iconify/json": "^2.1.131",
+    "@iconify-json/logos": "^1.1.18",
+    "@iconify-json/mdi": "^1.1.34",
     "nuxt": "^3.0.0",
     "unplugin-icons": "link:../.."
   }

--- a/examples/nuxt3/package.json
+++ b/examples/nuxt3/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@iconify/json": "^2.1.131",
-    "nuxt": "3.0.0-rc.12",
+    "nuxt": "^3.0.0",
     "unplugin-icons": "link:../.."
   }
 }

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,12 +1,14 @@
 import type { Options } from './types'
 import unplugin from '.'
 
-export default function (this: any, options: Options = {}) {
-  if (this.nuxt?._version?.startsWith('3.'))
+export default function (this: any, options: Options = {}, nuxt: any) {
+  const nuxtApp = this?.nuxt || nuxt
+
+  if (nuxtApp?._version?.startsWith('3.'))
     options.compiler = 'vue3'
 
   // install webpack plugin
-  this.nuxt.hook('webpack:config', (configs: any[]) => {
+  nuxtApp.hook('webpack:config', (configs: any[]) => {
     configs.forEach((config) => {
       config.plugins = config.plugins || []
       config.plugins.unshift(unplugin.webpack(options))
@@ -14,7 +16,7 @@ export default function (this: any, options: Options = {}) {
   })
 
   // install vite plugin
-  this.nuxt.hook('vite:extend', async (vite: any) => {
+  nuxtApp.hook('vite:extend', async (vite: any) => {
     vite.config.plugins = vite.config.plugins || []
     vite.config.plugins.push(unplugin.vite(options))
   })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Adds support with backward compatibility for the new Nuxt 3.0.0 stable release.

### Linked Issues

fixes #249 

### Additional context

Since there is no test regarding this feature currently and it requires different versions of Nuxt installed to validate, so I manually tested via `examples/nuxt3`.

* The example using `nuxt@3.0.0-rc.12` runs correctly before my change.
* The example using `nuxt@3.0.0` failed to run without my change.
	`Cannot read properties of undefined (reading 'nuxt')`
* The example using `nuxt@3.0.0` runs correctly with my change.
* The example using `nuxt@3.0.0-rc.12` runs correctly after my change. (backward compatible)
