### PR TITLE
Custom Elements: fix crash, add Shadow DOM option

### DIFF
--- a/src/core/compilers/web-components.ts
+++ b/src/core/compilers/web-components.ts
@@ -7,13 +7,19 @@ export const WebComponentsCompiler = <Compiler>((svg, collection, icon, { webCom
     id = `${options.iconPrefix}-${id}`
 
   const name = camelize(id)
-  return `
-export default class ${name} extends HTMLElement {
-  constructor() {
-    super()
-    this.innerHTML = ${JSON.stringify(svg)}
+  let code = `export default class ${name} extends HTMLElement {`
+  if (options.shadow) {
+    code += `constructor() {
+      super()
+      this.attachShadow({ mode: 'open' }).innerHTML = ${JSON.stringify(svg)}
+    }`
+  } else {
+    // use connectedCallback because children can't be appended in the constructor of a CE:
+    code += `connectedCallback() { this.innerHTML = ${JSON.stringify(svg)} }`
   }
-}
-${options.autoDefine ? `customElements.define('${id}', ${name})` : ''}
-`
+  code += `}`
+  if (options.autoDefine) {
+    code += `\ncustomElements.define('${id}', ${name})`
+  }
+  return code
 })


### PR DESCRIPTION
### Description

The current Web Components compiler produces an invalid Custom Element. When instantiated via `document.createElement('icon-a-b')`, it will throw an error: "Failed to construct 'CustomElement': The result must not have children".  The recommended solution from the CE spec is to append light DOM children in `connectedCallback`, so I've made that change here. I've also added a `shadow` option to have the generated CE use an open Shadow Root instead of light DOM children.

### Linked Issues

(none)

### Additional context

I made this change via GH web, so it doesn't include any of the TypeScript definition changes for the new `options.shadow` boolean.
