### PR TITLE
fix: update @vue/compiler-sfc peer dependency to support Vue 2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "peerDependencies": {
     "@svgr/core": ">=5.5.0",
-    "@vue/compiler-sfc": "^3.0.2",
+    "@vue/compiler-sfc": "^3.0.2" || "^2.7.0",
     "vue-template-compiler": "^2.6.12",
     "vue-template-es2015-compiler": "^1.9.0"
   },


### PR DESCRIPTION
Adds @vue/compiler-sfc 2.7 compiler as a valid option.

### Description

Currently following documentation to install unplugin-icons on vue 2.7 project and using automatic component resolution will add @vue/compiler-sfc as a dev dependency to the project.

However if project is created or installed from zero, npm install will fail as peer-dependency of the project request for @vue/compiler-sfc is 3+ as such.

This PR aims to add @vue/compiler-sfc 2.7 version as a optional peer dependency to allow clean installations of the library.

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR!
npm ERR! While resolving: unplugin-icons@0.15.0
npm ERR! Found: @vue/compiler-sfc@2.7.14
npm ERR! node_modules/@vue/compiler-sfc
npm ERR!   dev @vue/compiler-sfc@"^2.7.7" from the root project
npm ERR!   @vue/compiler-sfc@"2.7.14" from vue@2.7.14
npm ERR!   node_modules/vue
npm ERR!     vue@"^2.7.7" from the root project
npm ERR!     peer vue@"^2.7.0-0" from @vitejs/plugin-vue2@1.1.2
npm ERR!     node_modules/@vitejs/plugin-vue2
npm ERR!       dev @vitejs/plugin-vue2@"^1.1.2" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peerOptional @vue/compiler-sfc@"^3.0.2" from unplugin-icons@0.15.0
npm ERR! node_modules/unplugin-icons
npm ERR!   dev unplugin-icons@"^0.15.0" from the root project
npm ERR!
npm ERR! Conflicting peer dependency: @vue/compiler-sfc@3.2.45
npm ERR! node_modules/@vue/compiler-sfc
npm ERR!   peerOptional @vue/compiler-sfc@"^3.0.2" from unplugin-icons@0.15.0
npm ERR!   node_modules/unplugin-icons
npm ERR!     dev unplugin-icons@"^0.15.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

### Linked Issues


### Additional context
This change can be tested by trying to install package.json file as follows:
```
{
  "name": "vue-project",
  "version": "0.0.0",
  "scripts": {
    "dev": "vite",
    "build": "vite build",
    "preview": "vite preview --port 4173"
  },
  "dependencies": {
    "vue": "^2.7.7"
  },
  "devDependencies": {
    "@vitejs/plugin-legacy": "^2.0.0",
    "@vitejs/plugin-vue2": "^1.1.2",
    "@vue/compiler-sfc": "^2.7.7",
    "terser": "^5.14.2",
    "unplugin-icons": "^0.15.0",
    "vite": "^3.0.2"
  }
}

```