### PR TITLE
Fix preact type definition

### DIFF
--- a/types/preact.d.ts
+++ b/types/preact.d.ts
@@ -1,10 +1,10 @@
 declare module 'virtual:icons/*' {
-  import type { JSX, SVGProps } from 'preact'
-  const component: (props: SVGProps<SVGSVGElement>) => JSX.Element
+  import type { JSX } from 'preact'
+  const component: (props: JSX.SVGAttributes<SVGSVGElement>) => JSX.Element
   export default component
 }
 declare module '~icons/*' {
-  import type { JSX, SVGProps } from 'preact'
-  const component: (props: SVGProps<SVGSVGElement>) => JSX.Element
+  import type { JSX } from 'preact'
+  const component: (props: JSX.SVGAttributes<SVGSVGElement>) => JSX.Element
   export default component
 }


### PR DESCRIPTION
I've updated the module declarations for the icon components in the codebase to resolve an error that was occurring during project builds. The error message was:

```node_modules/unplugin-icons/types/preact.d.ts(2,22): error TS2305: Module '"node_modules/preact/src"' has no exported member 'SVGProps'.```

The error message indicates that Preact doesn't export the SVGProps interface like React does, so I've updated the type definition to use JSX.SVGAttributes instead. This should resolve the error.

Thank you for your time and consideration.