### PR TITLE
fix: JSX compiler using @svgr/core in CJS

### DIFF
--- a/src/core/compilers/jsx.ts
+++ b/src/core/compilers/jsx.ts
@@ -9,7 +9,7 @@ export const JSXCompiler = <Compiler>(async (
   options,
 ) => {
   const svgrCore = await importModule('@svgr/core')
-  // check for v6 transform, v5 default and previous versions
+  // check for v6/v7 transform (v7 on CJS it is in default), v5 default and previous versions
   const svgr = svgrCore.transform // v6 or v7 ESM
       || (svgrCore.default ? (svgrCore.default.transform /* v7 CJS */ ?? svgrCore.default) : svgrCore.default)
       || svgrCore


### PR DESCRIPTION
Current vite-react example not working, only when configuring type module.

closes #277