### PR TITLE
docs: adds `@svgr/plugin-jsx` to React/Preact README

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,10 +402,10 @@ Type Declarations
 <details>
 <summary>React</summary><br>
 
-JSX support requires peer dependency `@svgr/core`:
+JSX support requires peer dependency `@svgr/core` and its plugin `@svgr/plugin-jsx`:
 
 ```bash
-npm i -D @svgr/core
+npm i -D @svgr/core @svgr/plugin-jsx
 ```
 
 ```ts
@@ -433,10 +433,10 @@ Type Declarations
 <details>
 <summary>Preact</summary><br>
 
-JSX support requires peer dependency `@svgr/core`:
+JSX support requires peer dependency `@svgr/core` and its plugin `@svgr/plugin-jsx`:
 
 ```bash
-npm i -D @svgr/core
+npm i -D @svgr/core @svgr/plugin-jsx
 ```
 
 ```ts


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Since version [7.0.0](https://github.com/gregberge/svgr/releases/tag/v7.0.0) `@srvg/plugin-jsx` is not part of `@svgr/core` and have to be installed separately.

### Linked Issues

https://github.com/antfu/unplugin-icons/issues/275
https://github.com/antfu/unplugin-icons/pull/276

### Additional context

This has been fixed in the PR above, but users still need to install that dependency on their own, therefore the README needs to be updated.
