### PR TITLE
fix(compiler-solid): Props replacement not working with multiline starttags

### DIFF
--- a/src/core/compilers/solid.ts
+++ b/src/core/compilers/solid.ts
@@ -1,6 +1,6 @@
 import type { Compiler } from './types'
 
 export const SolidCompiler = ((svg: string) => {
-  const svgWithProps = svg.replace(/([{}])/g, '{\'$1\'}').replace(/(?<=<svg.*?)(>)/i, '{...props}>')
+  const svgWithProps = svg.replace(/([{}])/g, '{\'$1\'}').replace(/(?<=<svg[\s\S]*?)(>)/i, '{...props}>')
   return `export default (props = {}) => ${svgWithProps}`
 }) as Compiler


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:Props replacement wasn't working because the lookbehind only included the symbol '.', which doesn't match newlines.

According to [the spec](https://www.w3.org/TR/2006/REC-xml11-20060816/#sec-starttags), newlines can be included in the spacing in a starttag

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Props replacement wasn't working because the lookbehind only included the symbol '.', which doesn't match newlines.

According to [the XML spec](https://www.w3.org/TR/2006/REC-xml11-20060816/#sec-starttags), newlines can be included in the spacing in a starttag.

This was a very quick fix, so I figured I did not need to create an issue

Input:
```xml
<svg
  width="35"
  height="44"
  viewBox="0 0 35 44"
  fill="currentColor"
  xmlns="http://www.w3.org/2000/svg"
  role="presentation"
>
<!-- (left out, irrelevant) -->
</svg>
```

Output before fix:
```jsx
export default (props = {}) => <svg
  width="35"
  height="44"
  viewBox="0 0 35 44"
  fill="currentColor"
  xmlns="http://www.w3.org/2000/svg"
  role="presentation"
>
{/* (left out, irrelevant) */}
</svg>
```

Output after fix:
```jsx
export default (props = {}) => <svg
  width="35"
  height="44"
  viewBox="0 0 35 44"
  fill="currentColor"
  xmlns="http://www.w3.org/2000/svg"
  role="presentation"
{...props}>
{/* (left out, irrelevant) */}
</svg>
```