### PR TITLE
doc: fix vue version for when include compiler-sfc

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ See [the Astro + Vue example](examples/astro-vue) for a working example project.
 
 Vue 3 / Vue 2.7+ support requires peer dependency `@vue/compiler-sfc`:
 
-> Note that as of Vue 3.12.13+, this is no longer required as it is now included as a dependency of the main `vue` package.
+> Note that as of Vue 3.2.13+, this is no longer required as it is now included as a dependency of the main `vue` package.
 
 ```bash
 npm i -D @vue/compiler-sfc


### PR DESCRIPTION
### Description
fix README.
the version of vue include @vue/compiler-sfc is 3.2.13, but not 3.12.13+.
