### PR TITLE
feat(vite): add HMR support for local SVG

### DIFF
--- a/examples/vite-vue3/vite.config.ts
+++ b/examples/vite-vue3/vite.config.ts
@@ -45,6 +45,15 @@ const config: UserConfig = {
           props.color = 'skyblue'
         }
       },
+      hmrResolver(file, folder, normalizedSVGIconName) {
+        console.log(file, folder, normalizedSVGIconName)
+        if (file.endsWith('assets/giftbox.svg')) {
+          return 'inline/async'
+        }
+        if (folder.endsWith('assets/custom-a')) {
+          return `custom/${normalizedSVGIconName}`
+        }
+      },
     }),
     Components({
       dts: true,

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -17,6 +17,7 @@ export async function resolveOptions(options: Options): Promise<ResolvedOptions>
     transform,
     autoInstall = false,
     collectionsNodeResolvePath = process.cwd(),
+    hmrResolver,
   } = options
 
   const webComponents = Object.assign({
@@ -38,6 +39,7 @@ export async function resolveOptions(options: Options): Promise<ResolvedOptions>
     transform,
     autoInstall,
     collectionsNodeResolvePath,
+    hmrResolver,
   }
 }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR adds HMR support for Vite (only) for local SVG files, added a new `hmrResolver` option to resolve local icon collection/name from the file.

### Linked Issues

resolves #424

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
/cc @antfu maybe we can also add support for webpack and some others bundlers but I'm lazy to check them (sorry :pray:)
